### PR TITLE
make it build with ghc-8.2.2 as a dependency for typecraft

### DIFF
--- a/src/Game/Sequoia/Graphics.hs
+++ b/src/Game/Sequoia/Graphics.hs
@@ -7,6 +7,7 @@ module Game.Sequoia.Graphics where
 
 import           Data.Data
 import qualified Data.Text as T
+import           Data.Semigroup
 import           Game.Sequoia.Color (Color, black)
 import           Game.Sequoia.Types
 import           Graphics.Rendering.Cairo.Matrix (Matrix (..))


### PR DESCRIPTION
Despite it's not needed for recent ghc, it allows [typecraft](https://github.com/isovector/typecraft) build in its current state. It should not break builds with recent ghc (i.e. 8.6.5).